### PR TITLE
Fix post drafts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,6 +18,7 @@ class Post < ApplicationRecord
   alias_method :published, :published?
 
   def published=(is_published)
+    is_published = is_published == "1" || is_published == "true" if is_published.instance_of? String
     return published? if published? == is_published
     self.published_at = is_published ? Time.now : nil
     published?

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -29,7 +29,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Post.count') do
       post posts_url, params: {
         post: {
-          published: true,
+          published: "1",
           title: Faker::Games::DnD.alignment
         }
       }
@@ -40,7 +40,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should require a session to create a post" do
     assert_no_difference('Post.count') do
-      post posts_url, params: { post: { published: true, title: @post.title } }
+      post posts_url, params: { post: { published: "1", title: @post.title } }
     end
 
     assert_redirected_to login_path
@@ -64,12 +64,12 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update post" do
     login
-    patch post_url(@post), params: { post: { published: true, title: @post.title } }
+    patch post_url(@post), params: { post: { published: "1", title: @post.title } }
     assert_redirected_to post_url(@post)
   end
 
   test "should require a session to update a post" do
-    patch post_url(@post), params: { post: { published: true, title: @post.title } }
+    patch post_url(@post), params: { post: { published: "1", title: @post.title } }
     assert_redirected_to login_path
   end
 
@@ -97,7 +97,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_enqueued_with job: WebmentionJob, args: [{ source:, target: }] do
       post = post_params_with_links
-      post[:published] = true
+      post[:published] = "1"
       patch source, params: { post: }
     end
   end
@@ -118,7 +118,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_enqueued_with job: WebmentionJob do
       post = post_params_with_links
-      post[:published] = true
+      post[:published] = "1"
       post posts_url, params: {
         post:
       }
@@ -141,7 +141,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
       post posts_url, params: {
         post: {
           title: Faker::Games::DnD.alignment,
-          published: true,
+          published: "1",
           body: "<p>Test<a href=\"#{link}\">their post</a></p>"
         }
       }
@@ -163,7 +163,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
       post posts_url, params: {
         post: {
           title: Faker::Games::DnD.alignment,
-          published: true,
+          published: "1",
           body: <<~HTML
             <p>
               Test
@@ -195,6 +195,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   def post_params_with_links
     {
       title: Faker::Games::DnD.alignment,
+      published: "0",
       body: <<~HTML
         <p>
           Test

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -88,4 +88,12 @@ class PostTest < ActiveSupport::TestCase
     assert_not_empty post.errors[:slug]
     assert_equal ["is invalid"], post.errors[:slug]
   end
+
+  test "published should cast 1 and 0 strings to booleans" do
+    post = posts(:draft_post)
+    post.published = "1"
+    assert post.published?
+    post.published = "0"
+    assert_not post.published?
+  end
 end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -54,6 +54,23 @@ class PostsTest < ApplicationSystemTestCase
     click_on "Christophers thoughts"
   end
 
+  test "creating a draft Post" do
+    login
+
+    visit posts_url
+    click_on "Create new Post"
+    title = Faker::Games::DnD.alignment
+
+    fill_in "Title", with: title
+    fill_in_rich_text_area "Body", with: Faker::Lorem.paragraphs
+    click_on "Create Post"
+
+    assert_text "Post was successfully created"
+
+    click_on "Logout"
+    assert_no_text title
+  end
+
   test "creating a Post without a title" do
     login
 


### PR DESCRIPTION
Check-boxes send a "1" or "0" value in Rails. Post#published= didn't cast `"0"` to `false` but to `true`.
This is a fix for it.