### PR TITLE
Memory Store cache

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
   def index
-    @entries = Entry.published.with_entryables.limit 10
+    unless request.user_agent&.include? "Mastodon"
+      @entries = Entry.published.with_entryables.limit 10
+    else
+      @entries = []
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,5 @@
 class HomeController < ApplicationController
   def index
-    unless request.user_agent&.include? "Mastodon"
-      @entries = Entry.published.with_entryables.limit 10
-    else
-      @entries = []
-    end
+    @entries = Entry.published.with_entryables.limit 10
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -16,7 +16,11 @@
 #  index_entries_on_published_at  (published_at)
 #
 class Entry < ApplicationRecord
-  delegated_type :entryable, types: %w[ Bookmark Post ], dependent: :destroy
+  def self.types
+    %w[ Bookmark Post ]
+  end
+
+  delegated_type :entryable, types: self.types, dependent: :destroy
   accepts_nested_attributes_for :entryable, update_only: true
   has_and_belongs_to_many :tags
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :good_job

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,4 +5,30 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
   end
+
+  test "should have all entry types" do
+    get root_url
+
+    post = entries(:first_post)
+    bookmark = entries(:first_bookmark)
+
+    # Check if all types are tested
+    # This will fail as soon as a new type is added to Entry
+    types = [bookmark, post].map do |entry|
+      entry.entryable_type
+    end
+    assert_equal Entry.types, types, "All Entryable types should be tested"
+
+    assert_select "##{dom_id post} h1", text: post.title
+    assert_select "##{dom_id bookmark} h1", text: "Bookmarked: " + bookmark.title
+  end
+
+  test "should not load entries if user is Mastodon" do
+    process :get, root_url, headers: {
+      HTTP_USER_AGENT: "http.rb/5.1.0 (Mastodon/4.1.2; +https://social.example.org/)"
+    }
+
+    assert_response :success
+    assert_select "h1", 1
+  end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -22,13 +22,4 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "##{dom_id post} h1", text: post.title
     assert_select "##{dom_id bookmark} h1", text: "Bookmarked: " + bookmark.title
   end
-
-  test "should not load entries if user is Mastodon" do
-    process :get, root_url, headers: {
-      HTTP_USER_AGENT: "http.rb/5.1.0 (Mastodon/4.1.2; +https://social.example.org/)"
-    }
-
-    assert_response :success
-    assert_select "h1", 1
-  end
 end


### PR DESCRIPTION
Don't load entries on home if the user_agent is Mastodon. And switch to [memory cache](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memorystore) in production.