### PR TITLE
use turbo_stream for removing other sessions

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -48,7 +48,6 @@ class UserSessionsController < ApplicationController
   def destroy
     @user_session.destroy
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: turbo_stream.remove(@user_session) }
       format.html { redirect_to user_sessions_path, notice: t("sessions.logout_success"), status: :see_other }
       format.json { head :no_content }
     end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -48,6 +48,7 @@ class UserSessionsController < ApplicationController
   def destroy
     @user_session.destroy
     respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(@user_session) }
       format.html { redirect_to user_sessions_path, notice: t("sessions.logout_success"), status: :see_other }
       format.json { head :no_content }
     end

--- a/app/views/user_sessions/_user_session.html.erb
+++ b/app/views/user_sessions/_user_session.html.erb
@@ -21,7 +21,8 @@
       <% unless user_session == current_session %>
         | <%= link_to 'Destroy', user_session, data: {
           turbo_method: :delete,
-          turbo_confirm: 'Are you sure?'
+          turbo_frame: "_top",
+          turbo_confirm: "Are you sure?"
         } %>
       <% end %>
     </div>

--- a/app/views/user_sessions/_user_session.html.erb
+++ b/app/views/user_sessions/_user_session.html.erb
@@ -21,7 +21,6 @@
       <% unless user_session == current_session %>
         | <%= link_to 'Destroy', user_session, data: {
           turbo_method: :delete,
-          turbo_frame: "_top",
           turbo_confirm: "Are you sure?"
         } %>
       <% end %>

--- a/app/views/user_sessions/index.html.erb
+++ b/app/views/user_sessions/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1 class="text-center"><%= set_title(t 'sessions.active_list') %></h1>
 
 <%= turbo_stream_from "user_sessions" %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,6 +11,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     fill_in "name", with: "Test"
 
     click_button "Login"
-    sleep 0.5
+    sleep 0.4
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,6 +11,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     fill_in "name", with: "Test"
 
     click_button "Login"
-    sleep 0.3
+    sleep 0.5
   end
 end


### PR DESCRIPTION
There was a bug. It did redirect, and the result didn't have the old frame.

Other option would be to add target="_top" to the sessions frames.