### PR TITLE
Change update schedule to be weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,19 @@ updates:
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "thursday"
     versioning-strategy: increase
+    groups:
+      non-breaking-updates:
+        patterns:
+          - "*" # All dependecies that are minor or patch.
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"


### PR DESCRIPTION
Actions updates are done on wednesday, all other dependencies on thursday.

Minor and patch updates are grouped into one pull request.