### PR TITLE
add fediverse:creator meta data

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
     <% if content_for? :share_url %>
       <meta property="og:url" content="<%= yield(:share_url) %>">
     <% end %>
+    <meta name="fediverse:creator" content="<%= Rails.configuration.x.accounts.dig :mastodon, :user %>">
     <meta name="twitter:creator" content="<%= Rails.configuration.x.accounts.dig :twitter, :user %>">
   </head>
 

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,12 +1,12 @@
-require "test_helper"
+require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get root_url
     assert_response :success
   end
 
-  test "should have all entry types" do
+  test 'should have all entry types' do
     get root_url
 
     post = entries(:first_post)
@@ -14,12 +14,16 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     # Check if all types are tested
     # This will fail as soon as a new type is added to Entry
-    types = [bookmark, post].map do |entry|
-      entry.entryable_type
-    end
-    assert_equal Entry.types, types, "All Entryable types should be tested"
+    types = [bookmark, post].map(&:entryable_type)
+    assert_equal Entry.types, types, 'All Entryable types should be tested'
 
     assert_select "##{dom_id post} h1", text: post.title
-    assert_select "##{dom_id bookmark} h1", text: "Bookmarked: " + bookmark.title
+    assert_select "##{dom_id bookmark} h1", text: "Bookmarked: #{bookmark.title}"
+  end
+
+  test 'should have mastodon creator meta data' do
+    get root_url
+
+    assert_select "meta[name=\"fediverse:creator\"][content=\"#{Rails.configuration.x.accounts.dig :mastodon, :user}\"]"
   end
 end


### PR DESCRIPTION
Add the new [`fediverse:creator`](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) tag.